### PR TITLE
fixed playlist download, default output directory

### DIFF
--- a/spotifysaver/cli/commands/download/download.py
+++ b/spotifysaver/cli/commands/download/download.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import click
 
+from spotifysaver.config import Config
 from spotifysaver.services import SpotifyAPI, YoutubeMusicSearcher
 from spotifysaver.downloader import YouTubeDownloaderForCLI
 from spotifysaver.spotlog import LoggerConfig
@@ -22,7 +23,7 @@ from spotifysaver.cli.commands.download.track import process_track
 @click.option("--lyrics", is_flag=True, help="Download synced lyrics (.lrc)")
 @click.option("--nfo", is_flag=True, help="Generate Jellyfin NFO file for albums")
 @click.option("--cover", is_flag=True, help="Download album cover art")
-@click.option("--output", type=Path, default="Music", help="Output directory")
+@click.option("--output", type=Path, default=Config.OUTPUT_DIR, help="Output directory")#"Music", help="Output directory")
 @click.option("--format", type=click.Choice(["m4a", "mp3", "opus"]), default="m4a")
 @click.option("--bitrate", type=int, default=128, help="Audio bitrate in kbps")
 @click.option("--verbose", is_flag=True, help="Show debug output")

--- a/spotifysaver/config/setting_environment.py
+++ b/spotifysaver/config/setting_environment.py
@@ -53,6 +53,9 @@ class Config:
     # YouTube cookies file for bypassing age restrictions
     YTDLP_COOKIES_PATH = os.getenv("YTDLP_COOKIES_PATH", None)
 
+    # Default output directory
+    OUTPUT_DIR = os.getenv("SPOTIFYSAVER_OUTPUT_DIR", "Music")
+
     # Downloader configuration
     DOWNLOAD_TIMEOUT = os.getenv("DOWNLOAD_TIMEOUT", 10)
 

--- a/spotifysaver/downloader/youtube_downloader.py
+++ b/spotifysaver/downloader/youtube_downloader.py
@@ -182,19 +182,13 @@ class YouTubeDownloader:
         Returns:
             Path: Complete file path where the track should be saved
         """
-        if track.source_type == "playlist":
-            playlist_name = self._sanitize_filename(
-                track.playlist_name or "Unknown Playlist"
-            )
-            dir_path = self.base_dir / playlist_name
-        else:
-            artist_name = (
-                album_artist or track.artists[0] if track.artists else "Unknown Artist"
-            )
-            artist_name = self._sanitize_filename(artist_name)
-            album_name = self._sanitize_filename(track.album_name or "Unknown Album")
-            year = track.release_date[:4] if track.release_date else "Unknown"
-            dir_path = self.base_dir / artist_name / f"{album_name} ({year})"
+        artist_name = (
+            album_artist or track.artists[0] if track.artists else "Unknown Artist"
+        )
+        artist_name = self._sanitize_filename(artist_name)
+        album_name = self._sanitize_filename(track.album_name or "Unknown Album")
+        year = track.release_date[:4] if track.release_date else "Unknown"
+        dir_path = self.base_dir / artist_name / f"{album_name} ({year})"
 
         dir_path.mkdir(parents=True, exist_ok=True)
         track_name = self._sanitize_filename(track.name or "Unknown Track")

--- a/spotifysaver/services/spotify_api.py
+++ b/spotifysaver/services/spotify_api.py
@@ -158,10 +158,21 @@ class SpotifyAPI:
             playlist_id = self._extract_spotify_id(playlist_url)
             if not playlist_id:
                 raise ValueError("Invalid playlist URL")
-            return self.sp.playlist(playlist_id)
+            playlist = self.sp.playlist(playlist_id)
+            playlist["tracks"]['items'] = self._get_playlist_tracks(playlist_id)
+            return playlist
         except spotipy.exceptions.SpotifyException as e:
             self.logger.error(f"Error fetching playlist data: {e}")
             raise ValueError("Playlist not found or invalid URL") from e
+
+    def _get_playlist_tracks(self, playlist_id) ->list:
+            results = self.sp.playlist_tracks(playlist_id)
+            tracks = results['items']
+            while results['next']:
+                print(f"Fetching more tracks for playlist: {playlist_id}")
+                results = self.sp.next(results)
+                tracks.extend(results['items'])
+            return tracks
 
     @lru_cache(maxsize=32)
     def fetch_artist_albums(self, artist_url: str) -> dict:

--- a/spotifysaver/services/spotify_api.py
+++ b/spotifysaver/services/spotify_api.py
@@ -169,7 +169,6 @@ class SpotifyAPI:
             results = self.sp.playlist_tracks(playlist_id)
             tracks = results['items']
             while results['next']:
-                print(f"Fetching more tracks for playlist: {playlist_id}")
                 results = self.sp.next(results)
                 tracks.extend(results['items'])
             return tracks


### PR DESCRIPTION
## Description

Removed playlist specific code from _get_output_path()
I did this because the previous implementation would fail as artist_name was not specified.  
Additionally, I expected the function to simply download all of the songs from a playlist, putting them into a "playlist" folder doesnt offer a benifit 

updated _fetch_playlist_data() so it pulls all tracks instead of a max of 100

Additionally, added     
`OUTPUT_DIR = os.getenv("SPOTIFYSAVER_OUTPUT_DIR", "Music")`
to Config, and set default ouput drectory to this diirectory (still defaults to ./music if no value set)
 

## Type of change

Mark with an "x" what applies:

- [x] Bug fix 🐞
- [ ] New functionality ✨
- [ ] Code improvement/refactor 🔧
- [ ] Documentation 📚
- [ ] Other (please specify):

## Checklist

- [x] The branch is updated with `main`
- [x] The changes are tested and working
- [x] The tests have been updated (if applicable)
- [x] The documentation has been updated (if applicable)

## References

