### PR TITLE
bugfix(ui): Update ApiClient to use window.location.port

### DIFF
--- a/spotifysaver/ui/static/js/api-client.js
+++ b/spotifysaver/ui/static/js/api-client.js
@@ -1,8 +1,8 @@
 class ApiClient {
     constructor() {
-        this.apiUrl = `${window.location.protocol}//${window.location.hostname}:8000/api/v1`;
-        this.apiUrlHealth = `${window.location.protocol}//${window.location.hostname}:8000/health`;
-        this.apiUrlVersion = `${window.location.protocol}//${window.location.hostname}:8000/version`;
+        this.apiUrl = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/api/v1`;
+        this.apiUrlHealth = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/health`;
+        this.apiUrlVersion = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/version`;
         this.maxRetries = 3;
     }
 


### PR DESCRIPTION
## Description

I've steped in this bug trying to run this project behind a reverse proxy. Doing this I noticed the port stay fixed on 8000 even changing all variables in the project. You can fix it by adding `${window.location.port}` instead of a hardcoded 8000 in the main JS file.

## Type of change

Mark with an "x" what applies:

- [x] Bug fix 🐞
- [ ] New functionality ✨
- [ ] Code improvement/refactor 🔧
- [ ] Documentation 📚
- [ ] Other (please specify):

## Checklist

- [x] The branch is updated with `main`
- [x] The changes are tested and working
- [ ] The tests have been updated (if applicable)
- [ ] The documentation has been updated (if applicable)

## References

Related issues, architectural decisions, etc.