### PR TITLE
fix: update API URLs to use same-origin for reverse proxy compatibility

### DIFF
--- a/spotifysaver/ui/static/js/api-client.js
+++ b/spotifysaver/ui/static/js/api-client.js
@@ -1,8 +1,9 @@
 class ApiClient {
     constructor() {
-        this.apiUrl = `${window.location.protocol}//${window.location.hostname}:8000/api/v1`;
-        this.apiUrlHealth = `${window.location.protocol}//${window.location.hostname}:8000/health`;
-        this.apiUrlVersion = `${window.location.protocol}//${window.location.hostname}:8000/version`;
+        // Use same-origin URLs so reverse proxies (Traefik/Nginx/Caddy) work without exposing :8000.
+        this.apiUrl = `${window.location.origin}/api/v1`;
+        this.apiUrlHealth = `${window.location.origin}/health`;
+        this.apiUrlVersion = `${window.location.origin}/version`;
         this.maxRetries = 3;
     }
 


### PR DESCRIPTION
Fixes a reverse-proxy bug in the web UI: the frontend was hardcoded to call the API at `:8000` (for example `/health`), which fails when the app is exposed behind Traefik/Nginx on standard HTTPS.  
The change updates API endpoints in `spotifysaver/ui/static/js/api-client.js` to use same-origin URLs via `window.location.origin`, so the UI and API work correctly through the proxy.

## Type of change

Mark with an "x" what applies:

- [x] Bug fix 🐞
- [ ] New functionality ✨
- [ ] Code improvement/refactor 🔧
- [ ] Documentation 📚
- [ ] Other (please specify):

## Checklist

- [ ] The branch is updated with `main`
- [ ] The changes are tested and working
- [x] The tests have been updated (if applicable) *(not applicable; no behavior/tests added)*
- [ ] The documentation has been updated (if applicable)

## References

- Frontend fix in `spotifysaver/ui/static/js/api-client.js`
- Related behavior: UI calls to `https://<host>:8000/...` fail behind reverse proxy